### PR TITLE
Fixing type hint in remote manager.  IoC could not resolve without it.

### DIFF
--- a/RemoteManager.php
+++ b/RemoteManager.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Remote;
 
+use Illuminate\Foundation\Application;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -18,7 +19,7 @@ class RemoteManager {
 	 * @param  \Illuminate\Foundation\Application  $app
 	 * @return void
 	 */
-	public function __construct($app)
+	public function __construct(Application $app)
 	{
 		$this->app = $app;
 	}


### PR DESCRIPTION
Found this when pulling it in manually on a 4.3 install.  If I am correct that it is being removed from 4.3 and this is how we add it back, this one thing causes the following error.

```
exception 'Illuminate\Container\BindingResolutionException' with message 'Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Remote\RemoteManager' in /home/stygian/dev/base43/vendor/laravel/framework/src/Illuminate/Container/Container.php:677
```
