### PR TITLE
update phpseclib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "~5.0",
         "illuminate/filesystem": "~5.0",
-        "phpseclib/phpseclib": "0.3.*"
+        "phpseclib/phpseclib": "~1.0"
     },
     "require-dev": {
         "illuminate/console": "~5.0"


### PR DESCRIPTION
This package's phpseclib is too old.

When using Rocketeer, some warnings occured.

```
might@li653-209 ~/sources/tweetdiary-dev $ ~/.composer/vendor/bin/rocketeer check
| Check (Check if the server is ready to receive the application) [~0.78s]
PHP Warning:  unpack(): Type N: not enough input, need 4, have 1 in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2826

Warning: unpack(): Type N: not enough input, need 4, have 1 in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2826
PHP Warning:  extract() expects parameter 1 to be array, boolean given in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2826

Warning: extract() expects parameter 1 to be array, boolean given in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2826
PHP Notice:  Undefined variable: length in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2827

Notice: Undefined variable: length in /home/might/.composer/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php on line 2827
```
